### PR TITLE
fix : add MenuType field to distinguish menu types as enum

### DIFF
--- a/src/main/java/com/DevTino/festino_admin/menu/bean/UpdateMenuBean.java
+++ b/src/main/java/com/DevTino/festino_admin/menu/bean/UpdateMenuBean.java
@@ -35,6 +35,8 @@ public class UpdateMenuBean {
         menuDAO.setMenuPrice(requestMenuUpdateDTO.getMenuPrice());
         menuDAO.setIsSoldOut(requestMenuUpdateDTO.getIsSoldOut());
 
+        menuDAO.setMenuType(requestMenuUpdateDTO.getMenuType());
+
         menuDAO.setUpdateAt(LocalDateTime.now());
 
         // 수정한 DAO 저장

--- a/src/main/java/com/DevTino/festino_admin/menu/bean/small/CreateMenuDAOBean.java
+++ b/src/main/java/com/DevTino/festino_admin/menu/bean/small/CreateMenuDAOBean.java
@@ -22,6 +22,7 @@ public class CreateMenuDAOBean {
                 .createAt(LocalDateTime.now())
                 .updateAt(LocalDateTime.now())
                 .isSoldOut(requestMenuSaveDTO.getIsSoldOut())
+                .menuType(requestMenuSaveDTO.getMenuType())
                 .build();
     }
 }

--- a/src/main/java/com/DevTino/festino_admin/menu/bean/small/CreateMenuDTOBean.java
+++ b/src/main/java/com/DevTino/festino_admin/menu/bean/small/CreateMenuDTOBean.java
@@ -15,6 +15,7 @@ public class CreateMenuDTOBean {
                 .menuPrice(menuDAO.getMenuPrice())
                 .menuImage(menuDAO.getMenuImage())
                 .isSoldOut(menuDAO.getIsSoldOut())
+                .menuType(menuDAO.getMenuType().name())
                 .build();
     }
 }

--- a/src/main/java/com/DevTino/festino_admin/menu/domain/DTO/RequestMenuSaveDTO.java
+++ b/src/main/java/com/DevTino/festino_admin/menu/domain/DTO/RequestMenuSaveDTO.java
@@ -1,5 +1,6 @@
 package com.DevTino.festino_admin.menu.domain.DTO;
 
+import com.DevTino.festino_admin.menu.domain.MenuType;
 import lombok.Data;
 
 import java.util.UUID;
@@ -11,5 +12,6 @@ public class RequestMenuSaveDTO {
     Integer menuPrice;
     String menuDescription;
     String menuImage;
+    MenuType menuType;
     Boolean isSoldOut;
 }

--- a/src/main/java/com/DevTino/festino_admin/menu/domain/DTO/RequestMenuUpdateDTO.java
+++ b/src/main/java/com/DevTino/festino_admin/menu/domain/DTO/RequestMenuUpdateDTO.java
@@ -1,5 +1,6 @@
 package com.DevTino.festino_admin.menu.domain.DTO;
 
+import com.DevTino.festino_admin.menu.domain.MenuType;
 import lombok.Data;
 
 import java.util.UUID;
@@ -13,4 +14,5 @@ public class RequestMenuUpdateDTO {
     String menuDescription;
     Integer menuPrice;
     Boolean isSoldOut;
+    MenuType menuType;
 }

--- a/src/main/java/com/DevTino/festino_admin/menu/domain/DTO/ResponseMenuGetDTO.java
+++ b/src/main/java/com/DevTino/festino_admin/menu/domain/DTO/ResponseMenuGetDTO.java
@@ -14,4 +14,5 @@ public class ResponseMenuGetDTO {
     String menuDescription;
     Integer menuPrice;
     Boolean isSoldOut;
+    String menuType;
 }

--- a/src/main/java/com/DevTino/festino_admin/menu/domain/MenuDAO.java
+++ b/src/main/java/com/DevTino/festino_admin/menu/domain/MenuDAO.java
@@ -25,4 +25,5 @@ public class MenuDAO {
     Boolean isSoldOut;
     LocalDateTime createAt;
     LocalDateTime updateAt;
+    MenuType menuType;
 }

--- a/src/main/java/com/DevTino/festino_admin/menu/domain/MenuType.java
+++ b/src/main/java/com/DevTino/festino_admin/menu/domain/MenuType.java
@@ -1,0 +1,6 @@
+package com.DevTino.festino_admin.menu.domain;
+
+public enum MenuType {
+    // 메인메뉴, 서브메뉴
+    MAINMENU, SUBMENU
+}


### PR DESCRIPTION
## Docs

- [Issue Link](https://github.com/DEV-TINO/Festino-Admin-BE/issues/30)


## Changes

Enum을 통해 메뉴 종류를 구분하는 MenuType 필드 추가

## Review Points

추가한 MenuType 필드를 통해 메뉴 저장, 수정, 조회 API가 정상적으로 작동하는가

## Test Checklist

- [x] MenuType 필드 추가