### PR TITLE
fix : add menu image exception handling

### DIFF
--- a/src/main/java/com/DevTino/festino_admin/menu/bean/UpdateMenuBean.java
+++ b/src/main/java/com/DevTino/festino_admin/menu/bean/UpdateMenuBean.java
@@ -27,9 +27,14 @@ public class UpdateMenuBean {
         MenuDAO menuDAO = getMenuDAOBean.exec(requestMenuUpdateDTO.getMenuId(), requestMenuUpdateDTO.getBoothId());
         if(menuDAO == null) return null;
 
+        // 메뉴 이미지 넣지 않았을때 빈값으로 넣어주는 예외처리
+        String image = "";
+        if (requestMenuUpdateDTO.getMenuImage() != null)
+            image = requestMenuUpdateDTO.getMenuImage();
+
         // 찾은 DAO 수정
         menuDAO.setBoothId(requestMenuUpdateDTO.getBoothId());
-        menuDAO.setMenuImage(requestMenuUpdateDTO.getMenuImage());
+        menuDAO.setMenuImage(image);
         menuDAO.setMenuDescription(requestMenuUpdateDTO.getMenuDescription());
         menuDAO.setMenuName(requestMenuUpdateDTO.getMenuName());
         menuDAO.setMenuPrice(requestMenuUpdateDTO.getMenuPrice());

--- a/src/main/java/com/DevTino/festino_admin/menu/bean/small/CreateMenuDAOBean.java
+++ b/src/main/java/com/DevTino/festino_admin/menu/bean/small/CreateMenuDAOBean.java
@@ -12,12 +12,18 @@ public class CreateMenuDAOBean {
 
     // 메뉴 DAO 생성
     public MenuDAO exec(RequestMenuSaveDTO requestMenuSaveDTO) {
+
+        // 메뉴 이미지 넣지 않았을때 빈값으로 넣어주는 예외처리
+        String image = "";
+        if (requestMenuSaveDTO.getMenuImage() != null)
+            image = requestMenuSaveDTO.getMenuImage();
+
         return MenuDAO.builder()
                 .menuId(UUID.randomUUID())
                 .boothId(requestMenuSaveDTO.getBoothId())
                 .menuName(requestMenuSaveDTO.getMenuName())
                 .menuDescription(requestMenuSaveDTO.getMenuDescription())
-                .menuImage(requestMenuSaveDTO.getMenuImage())
+                .menuImage(image)
                 .menuPrice(requestMenuSaveDTO.getMenuPrice())
                 .createAt(LocalDateTime.now())
                 .updateAt(LocalDateTime.now())


### PR DESCRIPTION
## Docs

- [Issue Link](https://github.com/DEV-TINO/Festino-Admin-BE/issues/32)


## Changes
before
메뉴 저장, 수정 API에서 메뉴 이미지를 넣지 않을 시 null값으로 저장됨

after
예외 처리 코드를 추가해 빈값으로 저장되도록 수정

## Review Points

메뉴 이미지를 넣지 않았을 시 빈값으로 잘 들어가는가

## Test Checklist

- [x] 메뉴 이미지 예외처리(메뉴 저장, 수정시)