### PR TITLE
fix : add booth image exception handling

### DIFF
--- a/src/main/java/com/DevTino/festino_admin/booth/bean/UpdateDayBoothBean.java
+++ b/src/main/java/com/DevTino/festino_admin/booth/bean/UpdateDayBoothBean.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -30,7 +31,9 @@ public class UpdateDayBoothBean {
 
         // 부스 이미지를 넣지 않았을 때 빈값으로 넣어주는 예외처리
         List<String> boothImage = new ArrayList<>();
-        if (requestDayBoothUpdateDTO.getBoothImage() != null)
+        if (requestDayBoothUpdateDTO.getBoothImage() == null)
+            boothImage = Collections.singletonList("");
+        else
             boothImage = requestDayBoothUpdateDTO.getBoothImage();
 
         // DAO 수정

--- a/src/main/java/com/DevTino/festino_admin/booth/bean/UpdateFoodBoothBean.java
+++ b/src/main/java/com/DevTino/festino_admin/booth/bean/UpdateFoodBoothBean.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -35,7 +36,9 @@ public class UpdateFoodBoothBean {
 
         // 부스 이미지를 넣지 않았을 때 빈값으로 넣어주는 예외처리
         List<String> boothImage = new ArrayList<>();
-        if (requestFoodBoothUpdateDTO.getBoothImage() != null)
+        if (requestFoodBoothUpdateDTO.getBoothImage() == null)
+            boothImage = Collections.singletonList("");
+        else
             boothImage = requestFoodBoothUpdateDTO.getBoothImage();
 
         // DAO 수정

--- a/src/main/java/com/DevTino/festino_admin/booth/bean/UpdateNightBoothBean.java
+++ b/src/main/java/com/DevTino/festino_admin/booth/bean/UpdateNightBoothBean.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -31,7 +32,9 @@ public class UpdateNightBoothBean {
 
         // 부스 이미지를 넣지 않았을 때 빈값으로 넣어주는 예외처리
         List<String> boothImage = new ArrayList<>();
-        if (requestNightBoothUpdateDTO.getBoothImage() != null)
+        if (requestNightBoothUpdateDTO.getBoothImage() == null)
+            boothImage = Collections.singletonList("");
+        else
             boothImage = requestNightBoothUpdateDTO.getBoothImage();
 
         // DAO 수정

--- a/src/main/java/com/DevTino/festino_admin/booth/bean/small/CreateDayBoothDAOBean.java
+++ b/src/main/java/com/DevTino/festino_admin/booth/bean/small/CreateDayBoothDAOBean.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -18,7 +19,9 @@ public class CreateDayBoothDAOBean {
 
         // 부스 이미지를 넣지 않았을 때 빈값으로 넣어주는 예외처리
         List<String> boothImage = new ArrayList<>();
-        if (requestDayBoothSaveDTO.getBoothImage() != null)
+        if (requestDayBoothSaveDTO.getBoothImage() == null)
+            boothImage = Collections.singletonList("");
+        else
             boothImage = requestDayBoothSaveDTO.getBoothImage();
 
         return DayBoothDAO.builder()

--- a/src/main/java/com/DevTino/festino_admin/booth/bean/small/CreateFoodBoothDAOBean.java
+++ b/src/main/java/com/DevTino/festino_admin/booth/bean/small/CreateFoodBoothDAOBean.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -17,7 +18,9 @@ public class CreateFoodBoothDAOBean {
 
         // 부스 이미지를 넣지 않았을 때 빈값으로 넣어주는 예외처리
         List<String> boothImage = new ArrayList<>();
-        if (requestFoodBoothSaveDTO.getBoothImage() != null)
+        if (requestFoodBoothSaveDTO.getBoothImage() == null)
+            boothImage = Collections.singletonList("");
+        else
             boothImage = requestFoodBoothSaveDTO.getBoothImage();
 
         return FoodBoothDAO.builder()

--- a/src/main/java/com/DevTino/festino_admin/booth/bean/small/CreateNightBoothDAOBean.java
+++ b/src/main/java/com/DevTino/festino_admin/booth/bean/small/CreateNightBoothDAOBean.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -17,7 +18,9 @@ public class CreateNightBoothDAOBean {
 
         // 부스 이미지를 넣지 않았을 때 빈값으로 넣어주는 예외처리
         List<String> boothImage = new ArrayList<>();
-        if (requestNightBoothSaveDTO.getBoothImage() != null)
+        if (requestNightBoothSaveDTO.getBoothImage() == null)
+            boothImage = Collections.singletonList("");
+        else
             boothImage = requestNightBoothSaveDTO.getBoothImage();
 
         return NightBoothDAO.builder()


### PR DESCRIPTION
## Docs

- [Issue Link](https://github.com/DEV-TINO/Festino-Admin-BE/issues/33)


## Changes
before
부스 저장, 수정 API에서 메뉴 이미지를 넣지 않을 시 null값으로 저장됨

after
예외 처리 코드를 추가해 빈값으로 저장되도록 수정

## Review Points

부스 이미지를 넣지 않았을 시 빈값으로 잘 들어가는가

## Test Checklist

- [ ] 부스 이미지 예외처리(부스 저장, 수정시)