### PR TITLE
fix : add notice image exception handling

### DIFF
--- a/src/main/java/com/DevTino/festino_admin/notice/bean/UpdateNoticeBean.java
+++ b/src/main/java/com/DevTino/festino_admin/notice/bean/UpdateNoticeBean.java
@@ -36,10 +36,15 @@ public class UpdateNoticeBean {
         NoticeDAO noticeDAO = getNoticeDAOBean.exec(requestNoticeUpdateDTO.getNoticeId());
         if (noticeDAO == null) return null;
 
+        // 공지 이미지를 넣지 않았을 때 빈값으로 저장
+        String imageUrl = "";
+        if (requestNoticeUpdateDTO.getImageUrl() != null)
+            imageUrl = requestNoticeUpdateDTO.getImageUrl();
+
         // DAO 수정
         noticeDAO.setTitle(requestNoticeUpdateDTO.getTitle());
         noticeDAO.setWriterName(requestNoticeUpdateDTO.getWriterName());
-        noticeDAO.setImageUrl(requestNoticeUpdateDTO.getImageUrl());
+        noticeDAO.setImageUrl(imageUrl);
         noticeDAO.setContent(requestNoticeUpdateDTO.getContent());
         noticeDAO.setIsPin(requestNoticeUpdateDTO.getIsPin());
 

--- a/src/main/java/com/DevTino/festino_admin/notice/bean/small/CreateNoticeDAOBean.java
+++ b/src/main/java/com/DevTino/festino_admin/notice/bean/small/CreateNoticeDAOBean.java
@@ -11,13 +11,18 @@ import java.util.UUID;
 public class CreateNoticeDAOBean {
 
     public NoticeDAO exec(RequestNoticeSaveDTO requestNoticeSaveDTO){
+
+        // 공지 이미지를 넣지 않았을 때 빈값으로 저장
+        String imageUrl = "";
+        if (requestNoticeSaveDTO.getImageUrl() != null)
+            imageUrl = requestNoticeSaveDTO.getImageUrl();
         
         // 공지사항 DAO 생성해서 리턴
         return NoticeDAO.builder()
                 .noticeId(UUID.randomUUID())
                 .title(requestNoticeSaveDTO.getTitle())
                 .writerName(requestNoticeSaveDTO.getWriterName())
-                .imageUrl(requestNoticeSaveDTO.getImageUrl())
+                .imageUrl(imageUrl)
                 .content(requestNoticeSaveDTO.getContent())
                 .isPin(requestNoticeSaveDTO.getIsPin())
                 .createAt(LocalDateTime.now())


### PR DESCRIPTION
## Docs

- [Issue Link](https://github.com/DEV-TINO/Festino-Admin-BE/issues/32)


## Changes
before
공지 저장, 수정 API에서 메뉴 이미지를 넣지 않을 시 null값으로 저장됨

after
예외 처리 코드를 추가해 빈값으로 저장되도록 수정

## Review Points

공지 이미지를 넣지 않았을 시 빈값으로 잘 들어가는가

## Test Checklist

- [x] 공지 이미지 예외처리(공지 저장, 수정시)