### PR TITLE
fix : add-date

### DIFF
--- a/src/main/java/com/DevTino/festino_admin/order/bean/GetOrderAllBean.java
+++ b/src/main/java/com/DevTino/festino_admin/order/bean/GetOrderAllBean.java
@@ -24,10 +24,10 @@ public class GetOrderAllBean {
 
 
     // 주문 전체 조회
-    public List<ResponseOrderAllGetDTO> exec(){
+    public List<ResponseOrderAllGetDTO> exec(Integer date){
 
-        // Order 최신순 전체 조회 -> DAO 리스트
-        List<OrderDAO> daoList = getOrdersDAOBean.exec();
+        // 해당 날짜의 Order 최신순 전체 조회 -> DAO 리스트
+        List<OrderDAO> daoList = getOrdersDAOBean.exec(date);
         if (daoList == null) return null;
 
         // DAO 리스트를 DTO 리스트로 변환해 리턴

--- a/src/main/java/com/DevTino/festino_admin/order/bean/GetOrderCancelBean.java
+++ b/src/main/java/com/DevTino/festino_admin/order/bean/GetOrderCancelBean.java
@@ -24,10 +24,10 @@ public class GetOrderCancelBean {
 
 
     // 취소 주문 조회
-    public List<ResponseOrderCancelGetDTO> exec(){
+    public List<ResponseOrderCancelGetDTO> exec(Integer date){
 
-        // 취소된 Order 최신순 전체 조회 -> DAO 리스트
-        List<OrderDAO> daoList = getOrderCancelDAOBean.exec();
+        // 해당 날짜의 취소된 Order 최신순 전체 조회 -> DAO 리스트
+        List<OrderDAO> daoList = getOrderCancelDAOBean.exec(date);
         if (daoList == null) return null;
 
         // DAO 리스트를 DTO 리스트로 변환해 리턴

--- a/src/main/java/com/DevTino/festino_admin/order/bean/GetOrderCookingBean.java
+++ b/src/main/java/com/DevTino/festino_admin/order/bean/GetOrderCookingBean.java
@@ -23,14 +23,14 @@ public class GetOrderCookingBean {
     }
 
     // 조리중 주문 조회
-    public List<ResponseOrderCookingGetDTO> exec(UUID boothId){
+    public List<ResponseOrderCookingGetDTO> exec(UUID boothId, Integer date){
 
         // boothId로 해당 부스의 메뉴 검색
         List<MenuDAO> menuDAOList = getMenusDAOBean.exec(boothId);
         if (menuDAOList.isEmpty()) return null;
 
         // 메뉴 정보를 활용해 DTO 리스트를 생성해 리턴
-        return createOrderCookingGetDTOsBean.exec(menuDAOList);
+        return createOrderCookingGetDTOsBean.exec(menuDAOList, date);
 
     }
 

--- a/src/main/java/com/DevTino/festino_admin/order/bean/GetOrderFinishBean.java
+++ b/src/main/java/com/DevTino/festino_admin/order/bean/GetOrderFinishBean.java
@@ -24,10 +24,10 @@ public class GetOrderFinishBean {
 
 
     // 조리완료 주문 조회
-    public List<ResponseOrderFinishGetDTO> exec(){
+    public List<ResponseOrderFinishGetDTO> exec(Integer date){
 
-        // 조리완료 상태인 Order 최신순 전체 조회 -> DAO 리스트
-        List<OrderDAO> daoList = getOrderFinishDAOBean.exec();
+        // 해당 날짜의 조리완료 상태인 Order 최신순 전체 조회 -> DAO 리스트
+        List<OrderDAO> daoList = getOrderFinishDAOBean.exec(date);
         if (daoList == null) return null;
 
         // DAO 리스트를 DTO 리스트로 변환해 리턴

--- a/src/main/java/com/DevTino/festino_admin/order/bean/GetOrderNowBean.java
+++ b/src/main/java/com/DevTino/festino_admin/order/bean/GetOrderNowBean.java
@@ -30,18 +30,18 @@ public class GetOrderNowBean {
 
 
     // 실시간 주문 조회
-    public ResponseOrderNowGetDTO exec(UUID boothId){
+    public ResponseOrderNowGetDTO exec(UUID boothId, Integer date){
 
         // 입금대기 리스트 조회
-        List<ResponseOrderWaitDepositGetDTO> waitDepositList = getOrderWaitDepositBean.exec();
+        List<ResponseOrderWaitDepositGetDTO> waitDepositList = getOrderWaitDepositBean.exec(date);
         if (waitDepositList == null) return null;
 
         // 조리중 리스트 조회
-        List<ResponseOrderCookingGetDTO> cookingList = getOrderCookingBean.exec(boothId);
+        List<ResponseOrderCookingGetDTO> cookingList = getOrderCookingBean.exec(boothId, date);
         if (cookingList == null) return null;
 
         // 조리완료 리스트 조회
-        List<ResponseOrderFinishGetDTO> finishList = getOrderFinishBean.exec();
+        List<ResponseOrderFinishGetDTO> finishList = getOrderFinishBean.exec(date);
         if (finishList == null) return null;
 
         // DTO 생성해 반환

--- a/src/main/java/com/DevTino/festino_admin/order/bean/GetOrderTableBean.java
+++ b/src/main/java/com/DevTino/festino_admin/order/bean/GetOrderTableBean.java
@@ -24,10 +24,10 @@ public class GetOrderTableBean {
 
 
     // 테이블 주문 현황 조회
-    public List<ResponseOrderTableGetDTO> exec(){
+    public List<ResponseOrderTableGetDTO> exec(Integer date){
 
-        // 조리중인 Order 최신순 전체 조회
-        List<OrderDAO> orderDAOList = getOrderCookingDAOBean.exec();
+        // 해당 날짜의 조리중인 Order 최신순 전체 조회
+        List<OrderDAO> orderDAOList = getOrderCookingDAOBean.exec(date);
 
         // DAO 리스트를 DTO 리스트로 변환해 리턴
         return createOrderTableGetDTOsBean.exec(orderDAOList);

--- a/src/main/java/com/DevTino/festino_admin/order/bean/GetOrderWaitDepositBean.java
+++ b/src/main/java/com/DevTino/festino_admin/order/bean/GetOrderWaitDepositBean.java
@@ -24,10 +24,10 @@ public class GetOrderWaitDepositBean {
 
 
     // 입금대기 주문 조회
-    public List<ResponseOrderWaitDepositGetDTO> exec(){
+    public List<ResponseOrderWaitDepositGetDTO> exec(Integer date){
 
-        // 입금 대기 중인 Order 최신순 전체 조회 -> DAO 리스트
-        List<OrderDAO> daoList = getOrderWaitDepositDAOBean.exec();
+        // 해당 날짜의 입금 대기 중인 Order 최신순 전체 조회 -> DAO 리스트
+        List<OrderDAO> daoList = getOrderWaitDepositDAOBean.exec(date);
         if (daoList == null) return null;
 
         // DAO 리스트를 DTO 리스트로 변환해 리턴

--- a/src/main/java/com/DevTino/festino_admin/order/bean/small/CreateOrderCookingGetDTOBean.java
+++ b/src/main/java/com/DevTino/festino_admin/order/bean/small/CreateOrderCookingGetDTOBean.java
@@ -26,13 +26,13 @@ public class CreateOrderCookingGetDTOBean {
 
 
     // DTO 생성해 반환
-    public ResponseOrderCookingGetDTO exec(MenuDAO menuDAO){
+    public ResponseOrderCookingGetDTO exec(MenuDAO menuDAO, Integer date){
 
         // 각 메뉴에 해당하는 조리(Cook) 정보를 담을 List 생성
         List<Map<String, Object>> cooks = new ArrayList<>();
 
-        // menuName으로 조리중인 Cook 최신순 전체 조회
-        List<CookDAO> cookDAOList = getCooksDAOBean.exec(menuDAO.getMenuName(), false);
+        // menuName으로 해당 날짜의 조리중인 Cook 최신순 전체 조회
+        List<CookDAO> cookDAOList = getCooksDAOBean.exec(menuDAO.getMenuName(), false, date);
 
         // 주문한 테이블 총합, 남은 개수 총합
         Integer tableCount = 0;

--- a/src/main/java/com/DevTino/festino_admin/order/bean/small/CreateOrderCookingGetDTOsBean.java
+++ b/src/main/java/com/DevTino/festino_admin/order/bean/small/CreateOrderCookingGetDTOsBean.java
@@ -21,7 +21,7 @@ public class CreateOrderCookingGetDTOsBean {
 
 
     // 메뉴 한 개당 하나의 DTO를 생성, DTO 리스트를 만들어 반환
-    public List<ResponseOrderCookingGetDTO> exec(List<MenuDAO> menuDAOList){
+    public List<ResponseOrderCookingGetDTO> exec(List<MenuDAO> menuDAOList, Integer date){
 
         // DTO 리스트 생성
         List<ResponseOrderCookingGetDTO> orderCookingGetDTOList = new ArrayList<>();
@@ -30,7 +30,7 @@ public class CreateOrderCookingGetDTOsBean {
         for (MenuDAO menuDAO : menuDAOList){
             
             // 메뉴 한 개당 하나의 DTO 생성, DTO 리스트에 삽입
-            orderCookingGetDTOList.add(createOrderCookingGetDTOBean.exec(menuDAO));
+            orderCookingGetDTOList.add(createOrderCookingGetDTOBean.exec(menuDAO, date));
 
         }
 

--- a/src/main/java/com/DevTino/festino_admin/order/bean/small/GetCooksDAOBean.java
+++ b/src/main/java/com/DevTino/festino_admin/order/bean/small/GetCooksDAOBean.java
@@ -29,10 +29,10 @@ public class GetCooksDAOBean {
 
 
 
-    // menuName, isFinish로 Cook 최신순 전체 조회
-    public List<CookDAO> exec(String menuName, Boolean isFinish){
+    // menuName, isFinish, date로 Cook 최신순 전체 조회
+    public List<CookDAO> exec(String menuName, Boolean isFinish, Integer date){
 
-        return cookRepositoryJPA.findByMenuNameAndIsFinishOrderByCreateAtDesc(menuName, isFinish);
+        return cookRepositoryJPA.findByMenuNameAndIsFinishAndDateOrderByCreateAtDesc(menuName, isFinish, date);
 
     }
 

--- a/src/main/java/com/DevTino/festino_admin/order/bean/small/GetOrderCancelDAOBean.java
+++ b/src/main/java/com/DevTino/festino_admin/order/bean/small/GetOrderCancelDAOBean.java
@@ -20,10 +20,10 @@ public class GetOrderCancelDAOBean {
 
 
 
-    // 취소 상태인 Order 최신순 전체 조회
-    public List<OrderDAO> exec(){
+    // 해당 날짜의 취소 상태인 Order 최신순 전체 조회
+    public List<OrderDAO> exec(Integer date){
 
-        return orderRepositoryJPA.findByOrderTypeOrderByCreateAtDesc(OrderType.CANCEL);
+        return orderRepositoryJPA.findByOrderTypeAndDateOrderByCreateAtDesc(OrderType.CANCEL, date);
 
     }
 

--- a/src/main/java/com/DevTino/festino_admin/order/bean/small/GetOrderCookingDAOBean.java
+++ b/src/main/java/com/DevTino/festino_admin/order/bean/small/GetOrderCookingDAOBean.java
@@ -18,10 +18,10 @@ public class GetOrderCookingDAOBean {
         this.orderRepositoryJPA = orderRepositoryJPA;
     }
 
-    // 조리중인 Order 최신순 전체 조회
-    public List<OrderDAO> exec(){
+    // 해당 날짜의 조리중인 Order 최신순 전체 조회
+    public List<OrderDAO> exec(Integer date){
 
-        return orderRepositoryJPA.findByIsDepositAndOrderTypeOrderByCreateAtDesc(true, OrderType.COOKING);
+        return orderRepositoryJPA.findByIsDepositAndOrderTypeAndDateOrderByCreateAtDesc(true, OrderType.COOKING, date);
 
     }
 }

--- a/src/main/java/com/DevTino/festino_admin/order/bean/small/GetOrderFinishDAOBean.java
+++ b/src/main/java/com/DevTino/festino_admin/order/bean/small/GetOrderFinishDAOBean.java
@@ -20,10 +20,10 @@ public class GetOrderFinishDAOBean {
 
 
 
-    // 조리완료 상태인 Order 최신순 전체 조회
-    public List<OrderDAO> exec(){
+    // 해당 날짜의 조리완료 상태인 Order 최신순 전체 조회
+    public List<OrderDAO> exec(Integer date){
 
-        return orderRepositoryJPA.findByOrderTypeOrderByCreateAtDesc(OrderType.FINISH);
+        return orderRepositoryJPA.findByOrderTypeAndDateOrderByCreateAtDesc(OrderType.FINISH, date);
 
     }
 

--- a/src/main/java/com/DevTino/festino_admin/order/bean/small/GetOrderWaitDepositDAOBean.java
+++ b/src/main/java/com/DevTino/festino_admin/order/bean/small/GetOrderWaitDepositDAOBean.java
@@ -21,9 +21,9 @@ public class GetOrderWaitDepositDAOBean {
 
 
     // 입금대기 중인 Order 최신순 전체 조회
-    public List<OrderDAO> exec(){
+    public List<OrderDAO> exec(Integer date){
 
-        return orderRepositoryJPA.findByIsDepositAndOrderTypeOrderByCreateAtDesc(false, OrderType.COOKING);
+        return orderRepositoryJPA.findByIsDepositAndOrderTypeAndDateOrderByCreateAtDesc(false, OrderType.COOKING, date);
 
     }
 

--- a/src/main/java/com/DevTino/festino_admin/order/bean/small/GetOrdersDAOBean.java
+++ b/src/main/java/com/DevTino/festino_admin/order/bean/small/GetOrdersDAOBean.java
@@ -19,10 +19,10 @@ public class GetOrdersDAOBean {
 
 
 
-    // 전체 주문 최신순 조회
-    public List<OrderDAO> exec(){
+    // 해당 날짜의 전체 주문 최신순 조회
+    public List<OrderDAO> exec(Integer date){
 
-        return orderRepositoryJPA.findByOrderByCreateAtDesc();
+        return orderRepositoryJPA.findByDateOrderByCreateAtDesc(date);
 
     }
 

--- a/src/main/java/com/DevTino/festino_admin/order/controller/OrderController.java
+++ b/src/main/java/com/DevTino/festino_admin/order/controller/OrderController.java
@@ -27,11 +27,11 @@ public class OrderController {
 
 
     // 테이블 주문 현황 조회
-    @GetMapping("/table")
-    public ResponseEntity<Map<String, Object>> getOrderTable(){
+    @GetMapping("/table/{date}")
+    public ResponseEntity<Map<String, Object>> getOrderTable(@PathVariable Integer date){
 
         // 테이블 주문 현황 조회 service 실행
-        List<ResponseOrderTableGetDTO> dtoList = orderService.getOrderTable();
+        List<ResponseOrderTableGetDTO> dtoList = orderService.getOrderTable(date);
 
         // 테이블 주문 현황 조회 성공 여부 설정
         boolean success = (dtoList == null) ? false : true;
@@ -73,11 +73,11 @@ public class OrderController {
 
 
     // 전체 주문 조회
-    @GetMapping("/all")
-    public ResponseEntity<Map<String, Object>> getOrderAll(){
+    @GetMapping("/all/{date}")
+    public ResponseEntity<Map<String, Object>> getOrderAll(@PathVariable Integer date){
 
         // 전체 주문 조회 service 실행
-        List<ResponseOrderAllGetDTO> dtoList = orderService.getOrderAll();
+        List<ResponseOrderAllGetDTO> dtoList = orderService.getOrderAll(date);
 
         // 전체 주문 조회 성공 여부 설정
         boolean success = (dtoList == null) ? false : true;
@@ -96,11 +96,11 @@ public class OrderController {
 
 
     // 실시간 주문 조회
-    @GetMapping("/now/all")
-    public ResponseEntity<Map<String, Object>> getOrderNowAll(@PathVariable UUID boothId){
+    @GetMapping("/now/all/{date}")
+    public ResponseEntity<Map<String, Object>> getOrderNowAll(@PathVariable UUID boothId,@PathVariable Integer date){
 
         // 실시간 주문 조회 service 실행
-        ResponseOrderNowGetDTO responseOrderNowGetDTO = orderService.getOrderNowAll(boothId);
+        ResponseOrderNowGetDTO responseOrderNowGetDTO = orderService.getOrderNowAll(boothId, date);
 
         // 실시간 주문 조회 성공 여부 설정
         boolean success = (responseOrderNowGetDTO == null) ? false : true;
@@ -119,11 +119,11 @@ public class OrderController {
 
 
     // 입금대기 주문 조회
-    @GetMapping("/deposit/all")
-    public ResponseEntity<Map<String, Object>> getOrderWaitDepositAll(){
+    @GetMapping("/deposit/all/{date}")
+    public ResponseEntity<Map<String, Object>> getOrderWaitDepositAll(@PathVariable Integer date){
 
         // 입금대기 주문 조회 service 실행
-        List<ResponseOrderWaitDepositGetDTO> dtoList = orderService.getOrderWaitDepositAll();
+        List<ResponseOrderWaitDepositGetDTO> dtoList = orderService.getOrderWaitDepositAll(date);
 
         // 입금대기 주문 조회 성공 여부 설정
         boolean success = (dtoList == null) ? false : true;
@@ -142,11 +142,11 @@ public class OrderController {
 
 
     // 조리중 주문 조회
-    @GetMapping("/cooking/all")
-    public ResponseEntity<Map<String, Object>> getOrderCookingAll(@PathVariable UUID boothId){
+    @GetMapping("/cooking/all/{date}")
+    public ResponseEntity<Map<String, Object>> getOrderCookingAll(@PathVariable UUID boothId, @PathVariable Integer date){
 
         // 조리중 주문 조회 service 실행
-        List<ResponseOrderCookingGetDTO> dtoList = orderService.getOrderCookingAll(boothId);
+        List<ResponseOrderCookingGetDTO> dtoList = orderService.getOrderCookingAll(boothId, date);
 
         // 조리중 주문 조회 성공 여부 설정
         boolean success = (dtoList == null) ? false : true;
@@ -165,11 +165,11 @@ public class OrderController {
 
 
     // 조리완료 주문 조회
-    @GetMapping("/finish/all")
-    public ResponseEntity<Map<String, Object>> getOrderFinishAll(){
+    @GetMapping("/finish/all/{date}")
+    public ResponseEntity<Map<String, Object>> getOrderFinishAll(@PathVariable Integer date){
 
         // 조리완료 주문 조회 service 실행
-        List<ResponseOrderFinishGetDTO> dtoList = orderService.getOrderFinishAll();
+        List<ResponseOrderFinishGetDTO> dtoList = orderService.getOrderFinishAll(date);
 
         // 조리완료 주문 조회 성공 여부 설정
         boolean success = (dtoList == null) ? false : true;
@@ -188,11 +188,11 @@ public class OrderController {
 
 
     // 취소 주문 조회
-    @GetMapping("/cancel/all")
-    public ResponseEntity<Map<String, Object>> getOrderCancelAll(){
+    @GetMapping("/cancel/all/{date}")
+    public ResponseEntity<Map<String, Object>> getOrderCancelAll(@PathVariable Integer date){
 
         // 취소 주문 조회 service 실행
-        List<ResponseOrderCancelGetDTO> dtoList = orderService.getOrderCancelAll();
+        List<ResponseOrderCancelGetDTO> dtoList = orderService.getOrderCancelAll(date);
 
         // 취소 주문 조회 성공 여부 설정
         boolean success = (dtoList == null) ? false : true;

--- a/src/main/java/com/DevTino/festino_admin/order/repository/CookRepositoryJPA.java
+++ b/src/main/java/com/DevTino/festino_admin/order/repository/CookRepositoryJPA.java
@@ -11,8 +11,8 @@ public interface CookRepositoryJPA extends JpaRepository<CookDAO, UUID> {
     // orderId에 해당하는 Cook 검색
     public List<CookDAO> findAllByOrderId(UUID orderId);
 
-    // menuName에 해당하는 Cook 검색
-    public List<CookDAO> findByMenuNameAndIsFinishOrderByCreateAtDesc(String menuName, Boolean isFinish);
+    // menuName, isFinish, date에 해당하는 Cook 검색
+    public List<CookDAO> findByMenuNameAndIsFinishAndDateOrderByCreateAtDesc(String menuName, Boolean isFinish, Integer date);
 
     // menuName, date에 해당하는 Cook 검색
     public List<CookDAO> findByMenuNameAndDate(String menuName, Integer date);

--- a/src/main/java/com/DevTino/festino_admin/order/repository/OrderRepositoryJPA.java
+++ b/src/main/java/com/DevTino/festino_admin/order/repository/OrderRepositoryJPA.java
@@ -9,13 +9,13 @@ import java.util.UUID;
 
 public interface OrderRepositoryJPA extends JpaRepository<OrderDAO, UUID> {
 
-    // 전체 주문 최신순 검색
-    public List<OrderDAO> findByOrderByCreateAtDesc();
+    // 해당 날짜의 전체 주문 최신순 검색
+    public List<OrderDAO> findByDateOrderByCreateAtDesc(Integer date);
 
     // OrderType으로 주문 최신순 검색
-    public List<OrderDAO> findByOrderTypeOrderByCreateAtDesc(OrderType orderType);
+    public List<OrderDAO> findByOrderTypeAndDateOrderByCreateAtDesc(OrderType orderType, Integer date);
 
-    // isDeposit, OrderType으로 주문 최신순 검색
-    public List<OrderDAO> findByIsDepositAndOrderTypeOrderByCreateAtDesc(Boolean isDeposit, OrderType orderType);
+    // isDeposit, OrderType, date로 주문 최신순 검색
+    public List<OrderDAO> findByIsDepositAndOrderTypeAndDateOrderByCreateAtDesc(Boolean isDeposit, OrderType orderType, Integer date);
     
 }

--- a/src/main/java/com/DevTino/festino_admin/order/service/OrderService.java
+++ b/src/main/java/com/DevTino/festino_admin/order/service/OrderService.java
@@ -48,9 +48,9 @@ public class OrderService {
 
 
     // 테이블 주문 현황 조회
-    public List<ResponseOrderTableGetDTO> getOrderTable(){
+    public List<ResponseOrderTableGetDTO> getOrderTable(Integer date){
 
-        return getOrderTableBean.exec();
+        return getOrderTableBean.exec(date);
 
     }
 
@@ -66,54 +66,54 @@ public class OrderService {
 
 
     // 전체 주문 조회
-    public List<ResponseOrderAllGetDTO> getOrderAll(){
+    public List<ResponseOrderAllGetDTO> getOrderAll(Integer date){
 
-        return getOrderAllBean.exec();
+        return getOrderAllBean.exec(date);
 
     }
 
 
 
     // 실시간 주문 조회
-    public ResponseOrderNowGetDTO getOrderNowAll(UUID boothId){
+    public ResponseOrderNowGetDTO getOrderNowAll(UUID boothId, Integer date){
 
-        return getOrderNowBean.exec(boothId);
+        return getOrderNowBean.exec(boothId, date);
 
     }
 
 
 
     // 입금대기 주문 조회
-    public List<ResponseOrderWaitDepositGetDTO> getOrderWaitDepositAll(){
+    public List<ResponseOrderWaitDepositGetDTO> getOrderWaitDepositAll(Integer date){
 
-        return getOrderWaitDepositBean.exec();
+        return getOrderWaitDepositBean.exec(date);
 
     }
 
 
 
     // 조리중 주문 조회
-    public List<ResponseOrderCookingGetDTO> getOrderCookingAll(UUID boothId){
+    public List<ResponseOrderCookingGetDTO> getOrderCookingAll(UUID boothId, Integer date){
 
-        return getOrderCookingBean.exec(boothId);
+        return getOrderCookingBean.exec(boothId, date);
 
     }
 
 
 
     // 조리완료 주문 조회
-    public List<ResponseOrderFinishGetDTO> getOrderFinishAll(){
+    public List<ResponseOrderFinishGetDTO> getOrderFinishAll(Integer date){
 
-        return getOrderFinishBean.exec();
+        return getOrderFinishBean.exec(date);
 
     }
 
 
 
     // 취소 주문 조회
-    public List<ResponseOrderCancelGetDTO> getOrderCancelAll(){
+    public List<ResponseOrderCancelGetDTO> getOrderCancelAll(Integer date){
 
-        return getOrderCancelBean.exec();
+        return getOrderCancelBean.exec(date);
 
     }
 


### PR DESCRIPTION
## Docs

- [Issue Link](https://github.com/DEV-TINO/Festino-Admin-BE/issues/48#issue-2421304744)


## Changes

테이블 / 전체 / 실시간 / 입금대기 / 조리중 / 조리완료 / 취소 주문 조회 시 date 값을 입력받아, 해당 날짜의 정보만 보내도록 수정

## Review Points

Order 관련 API가 정상 동작하는가
- order
  - 테이블 주문 현황 조회 : `/admin/booth/{boothId}/order/table/{date}`
  - 전체 주문 조회 : `/admin/booth/{boothId}/order/all/{date}`
  - 실시간 조회 : `/admin/booth/{boothId}/order/now/all/{date}`
  - 입금대기 주문 조회 : `/admin/booth/{boothId}/order/wait-deposit/{date}`
  - 조리중 조회 : `/admin/booth/{boothId}/order/cooking/all/{date}`
  - 조리완료 주문 조회 : `/admin/booth/{boothId}/order/finish/{date}`
  - 취소 주문 조회 : `/admin/booth/{boothId}/order/cancel/{date}`

## Test Checklist
  - 테이블 주문 현황 조회 API
  - 전체 주문 조회 API
  - 실시간 조회 API
  - 입금대기 주문 조회 API
  - 조리중 조회 API
  - 조리완료 주문 조회 API
  - 취소 주문 조회 API