### PR TITLE
fix : add boothId

### DIFF
--- a/src/main/java/com/DevTino/festino_admin/order/bean/small/CreateCookDAOBean.java
+++ b/src/main/java/com/DevTino/festino_admin/order/bean/small/CreateCookDAOBean.java
@@ -11,11 +11,13 @@ import java.util.UUID;
 @Component
 public class CreateCookDAOBean {
 
+    // DAO 생성해 반환
     public CookDAO exec(Map<String, Object> menu, OrderDAO orderDAO){
 
         return CookDAO.builder()
                 .cookId(UUID.randomUUID())
                 .orderId(orderDAO.getOrderId())
+                .boothId(orderDAO.getBoothId())
                 .date(orderDAO.getDate())
                 .menuName((String) menu.get("menuName"))
                 .totalCount((Integer) menu.get("menuCount"))


### PR DESCRIPTION
## Docs

- [Issue Link](https://github.com/DEV-TINO/Festino-Admin-BE/issues/52#issue-2421343419)


## Changes

- Order 입금 확인에서 CookDAO 생성 시 boothId도 Order에서 함께 받아 설정하도록 수정

## Review Points

- [x] CreateCookDAOBean이 올바르게 수정되었는가