### PR TITLE
fix : Get Cooking Orders

### DIFF
--- a/src/main/java/com/DevTino/festino_admin/order/bean/small/CreateCookDAOBean.java
+++ b/src/main/java/com/DevTino/festino_admin/order/bean/small/CreateCookDAOBean.java
@@ -5,7 +5,6 @@ import com.DevTino.festino_admin.order.domain.CookDAO;
 import com.DevTino.festino_admin.order.domain.OrderDAO;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.UUID;
 
@@ -19,6 +18,7 @@ public class CreateCookDAOBean {
                 .cookId(UUID.randomUUID())
                 .orderId(orderDAO.getOrderId())
                 .boothId(orderDAO.getBoothId())
+                .tableNum(orderDAO.getTableNum())
                 .date(orderDAO.getDate())
                 .menuName((String) menu.get("menuName"))
                 .totalCount((Integer) menu.get("menuCount"))

--- a/src/main/java/com/DevTino/festino_admin/order/bean/small/CreateOrderCookingGetDTOBean.java
+++ b/src/main/java/com/DevTino/festino_admin/order/bean/small/CreateOrderCookingGetDTOBean.java
@@ -12,12 +12,10 @@ import java.util.*;
 public class CreateOrderCookingGetDTOBean {
 
     GetCooksDAOBean getCooksDAOBean;
-    GetOrderDAOBean getOrderDAOBean;
 
     @Autowired
-    public CreateOrderCookingGetDTOBean(GetCooksDAOBean getCooksDAOBean, GetOrderDAOBean getOrderDAOBean){
+    public CreateOrderCookingGetDTOBean(GetCooksDAOBean getCooksDAOBean){
         this.getCooksDAOBean = getCooksDAOBean;
-        this.getOrderDAOBean = getOrderDAOBean;
     }
 
 
@@ -41,7 +39,7 @@ public class CreateOrderCookingGetDTOBean {
             // CookDAO의 정보로 Map 생성
             Map<String, Object> map = new HashMap<>();
             map.put("cookId", cookDAO.getCookId());
-            map.put("tableNum", getOrderDAOBean.exec(cookDAO.getOrderId()).getTableNum());
+            map.put("tableNum", cookDAO.getTableNum());
             map.put("totalCount", cookDAO.getTotalCount());
             map.put("servedCount", cookDAO.getServedCount());
 

--- a/src/main/java/com/DevTino/festino_admin/order/domain/CookDAO.java
+++ b/src/main/java/com/DevTino/festino_admin/order/domain/CookDAO.java
@@ -19,6 +19,7 @@ public class CookDAO {
     UUID cookId;
     UUID orderId;
     UUID boothId;
+    Integer tableNum;
     Integer date;
     String menuName;
     Integer totalCount;


### PR DESCRIPTION
## Docs

- [Issue Link](https://github.com/DEV-TINO/Festino-Admin-BE/issues/84#issue-2433943468)


## Changes
 cook에서 order 조회를 통해 tableNum 가져오는 로직 제거
cook을 생성할 때 tableNum을 함께 저장하도록 수정


## Review Points

Order 관련 API가 정상 동작하는가
- order
  - 조리중 주문 조회 : `/admin/booth/{boothId}/order/cooking/all/{date}`

## Test Checklist
- [x] 조리중 주문 조회 API