### PR TITLE
fix : class casting error : `menuInfo` to `List<MenuInfoDTO>`

### DIFF
--- a/src/main/java/com/DevTino/festino_admin/order/bean/small/CreateCookDAOsBean.java
+++ b/src/main/java/com/DevTino/festino_admin/order/bean/small/CreateCookDAOsBean.java
@@ -3,6 +3,8 @@ package com.DevTino.festino_admin.order.bean.small;
 import com.DevTino.festino_admin.order.domain.CookDAO;
 import com.DevTino.festino_admin.order.domain.DTO.MenuInfoDTO;
 import com.DevTino.festino_admin.order.domain.OrderDAO;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -28,21 +30,34 @@ public class CreateCookDAOsBean {
     // orderDAO의 메뉴 정보에 따라 CookDAO 생성
     public void exec(OrderDAO orderDAO){
 
-        // 메뉴 정보 받기
-        List<MenuInfoDTO> menuList = orderDAO.getMenuInfo();
-
         // Cook DAO 리스트 생성
         List<CookDAO> cookDAOList = new ArrayList<>();
 
-        // menuList에서 하나씩 꺼내서
-        for (MenuInfoDTO menu : menuList){
+        try {
 
-            // 메뉴 정보로 Cook DAO 생성
-            CookDAO cookDAO = createCookDAOBean.exec(menu, orderDAO);
+            // ObjectMapper 설정
+            ObjectMapper objectMapper = new ObjectMapper();
+            List<MenuInfoDTO> menuList = new ArrayList<>();
+            String menuListString = null;
 
-            // 생성한 Cook DAO 리스트에 적재
-            cookDAOList.add(cookDAO);
+            // ObjectMapper를 이용해 menuInfo를 String 타입으로 변환
+            menuListString = objectMapper.writeValueAsString(orderDAO.getMenuInfo());
 
+            // ObjectMapper를 이용해 String 타입으로 변환된 menuInfo를 List<MenuInfo>로 매핑
+            menuList = objectMapper.readValue(menuListString, new TypeReference<List<MenuInfoDTO>>() {});
+            
+            // menuList에서 하나씩 꺼내서
+            for (MenuInfoDTO menu : menuList) {
+
+                // 메뉴 정보로 Cook DAO 생성
+                CookDAO cookDAO = createCookDAOBean.exec(menu, orderDAO);
+
+                // 생성한 Cook DAO 리스트에 적재
+                cookDAOList.add(cookDAO);
+
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
         }
 
         // Cook DAO 리스트 저장


### PR DESCRIPTION
## Docs

- [Issue Link](https://github.com/DEV-TINO/Festino-Admin-BE/issues/106#issue-2489084283)
- [Issue Link](https://github.com/DEV-TINO/Festino/issues/5#issue-2489500106)


## Changes

1. Order의 menuInfo 정보로 Cook들을 생성하는 과정에서 ObjectMapper 사용해 menuInfo를 `List<MenuInfo>`로 명시적으로 변환해주도록 수정

## Review Points

수정된 API가 정상 동작하는가
- order
  - 입금 확인: `/admin/booth/{boothId}/order/deposit` - `PUT`

## Test Checklist
- [x] 입금 확인 API