### PR TITLE
fix : substitute another value in `fromOrderDTO`

### DIFF
--- a/src/main/java/com/DevTino/festino_admin/order/domain/ComputerOrderDAO.java
+++ b/src/main/java/com/DevTino/festino_admin/order/domain/ComputerOrderDAO.java
@@ -43,7 +43,7 @@ public class ComputerOrderDAO {
                 .boothId(orderDTO.getBoothId())
                 .orderType(orderDTO.getOrderType())
                 .tableNum(orderDTO.getTableNum())
-                .date(orderDTO.getOrderNum())
+                .date(orderDTO.getDate())
                 .userName(orderDTO.getUserName())
                 .phoneNum(orderDTO.getPhoneNum())
                 .totalPrice(orderDTO.getTotalPrice())

--- a/src/main/java/com/DevTino/festino_admin/order/domain/ElectronicsOrderDAO.java
+++ b/src/main/java/com/DevTino/festino_admin/order/domain/ElectronicsOrderDAO.java
@@ -43,7 +43,7 @@ public class ElectronicsOrderDAO {
                 .boothId(orderDTO.getBoothId())
                 .orderType(orderDTO.getOrderType())
                 .tableNum(orderDTO.getTableNum())
-                .date(orderDTO.getOrderNum())
+                .date(orderDTO.getDate())
                 .userName(orderDTO.getUserName())
                 .phoneNum(orderDTO.getPhoneNum())
                 .totalPrice(orderDTO.getTotalPrice())

--- a/src/main/java/com/DevTino/festino_admin/order/domain/EnergyOrderDAO.java
+++ b/src/main/java/com/DevTino/festino_admin/order/domain/EnergyOrderDAO.java
@@ -43,7 +43,7 @@ public class EnergyOrderDAO {
                 .boothId(orderDTO.getBoothId())
                 .orderType(orderDTO.getOrderType())
                 .tableNum(orderDTO.getTableNum())
-                .date(orderDTO.getOrderNum())
+                .date(orderDTO.getDate())
                 .userName(orderDTO.getUserName())
                 .phoneNum(orderDTO.getPhoneNum())
                 .totalPrice(orderDTO.getTotalPrice())

--- a/src/main/java/com/DevTino/festino_admin/order/domain/GameOrderDAO.java
+++ b/src/main/java/com/DevTino/festino_admin/order/domain/GameOrderDAO.java
@@ -43,7 +43,7 @@ public class GameOrderDAO {
                 .boothId(orderDTO.getBoothId())
                 .orderType(orderDTO.getOrderType())
                 .tableNum(orderDTO.getTableNum())
-                .date(orderDTO.getOrderNum())
+                .date(orderDTO.getDate())
                 .userName(orderDTO.getUserName())
                 .phoneNum(orderDTO.getPhoneNum())
                 .totalPrice(orderDTO.getTotalPrice())

--- a/src/main/java/com/DevTino/festino_admin/order/domain/MachineOrderDAO.java
+++ b/src/main/java/com/DevTino/festino_admin/order/domain/MachineOrderDAO.java
@@ -43,7 +43,7 @@ public class MachineOrderDAO {
                 .boothId(orderDTO.getBoothId())
                 .orderType(orderDTO.getOrderType())
                 .tableNum(orderDTO.getTableNum())
-                .date(orderDTO.getOrderNum())
+                .date(orderDTO.getDate())
                 .userName(orderDTO.getUserName())
                 .phoneNum(orderDTO.getPhoneNum())
                 .totalPrice(orderDTO.getTotalPrice())

--- a/src/main/java/com/DevTino/festino_admin/order/domain/NanoOrderDAO.java
+++ b/src/main/java/com/DevTino/festino_admin/order/domain/NanoOrderDAO.java
@@ -43,7 +43,7 @@ public class NanoOrderDAO {
                 .boothId(orderDTO.getBoothId())
                 .orderType(orderDTO.getOrderType())
                 .tableNum(orderDTO.getTableNum())
-                .date(orderDTO.getOrderNum())
+                .date(orderDTO.getDate())
                 .userName(orderDTO.getUserName())
                 .phoneNum(orderDTO.getPhoneNum())
                 .totalPrice(orderDTO.getTotalPrice())

--- a/src/main/java/com/DevTino/festino_admin/order/domain/NewMaterialOrderDAO.java
+++ b/src/main/java/com/DevTino/festino_admin/order/domain/NewMaterialOrderDAO.java
@@ -43,7 +43,7 @@ public class NewMaterialOrderDAO {
                 .boothId(orderDTO.getBoothId())
                 .orderType(orderDTO.getOrderType())
                 .tableNum(orderDTO.getTableNum())
-                .date(orderDTO.getOrderNum())
+                .date(orderDTO.getDate())
                 .userName(orderDTO.getUserName())
                 .phoneNum(orderDTO.getPhoneNum())
                 .totalPrice(orderDTO.getTotalPrice())


### PR DESCRIPTION
## Docs

- [Issue Link](https://github.com/DEV-TINO/Festino-Admin-BE/issues/107#issue-2493340018)
- [Issue Link](https://github.com/DEV-TINO/Festino/issues/5#issue-2489500106)


## Changes

1. 학과별 OrderDAO의 `fromOrderDTO` 수정 : `date`에 (`tableNum`이 아닌) `date`가 제대로 들어가도록

## Review Points

수정된 API가 정상 동작하는가, 문제 발생한 API가 정상 기능하는가
- order
  - 입금 확인: `/admin/booth/{boothId}/order/deposit` - `PUT`
  - 조리중 주문 조회: `/admin/booth/{boothId}/order/cooking` - `GET`

## Test Checklist
- [x] 입금 확인 API
- [x] 조리중 주문 조회 API