### PR TITLE
fix : Get Cooking Orders

### DIFF
--- a/src/main/java/com/DevTino/festino_admin/order/bean/small/CreateOrderCookingGetDTOBean.java
+++ b/src/main/java/com/DevTino/festino_admin/order/bean/small/CreateOrderCookingGetDTOBean.java
@@ -26,6 +26,9 @@ public class CreateOrderCookingGetDTOBean {
 
         // menuId로 해당 학과에 맞는 날짜의 조리중인 Cook 오래된순 전체 조회
         List<CookDTO> cookDTOList = getCooksDAOBean.exec(adminName, menuDAO.getMenuId(), false, date);
+        
+        // 메뉴가 삭제된 상태이고, 메뉴로 조회한 CookList도 비어 있다면 null 리턴
+        if (menuDAO.getIsDeleted() && cookDTOList.isEmpty()) return null;
 
         // 주문한 테이블 총합, 남은 개수 총합
         Integer tableCount = 0;

--- a/src/main/java/com/DevTino/festino_admin/order/bean/small/CreateOrderCookingGetDTOsBean.java
+++ b/src/main/java/com/DevTino/festino_admin/order/bean/small/CreateOrderCookingGetDTOsBean.java
@@ -29,8 +29,11 @@ public class CreateOrderCookingGetDTOsBean {
         // MenuDAOList에서 Menu DAO 하나씩 꺼내서
         for (MenuDAO menuDAO : menuDAOList){
 
-            // 메뉴 한 개당 하나의 DTO 생성, DTO 리스트에 삽입
-            orderCookingGetDTOList.add(createOrderCookingGetDTOBean.exec(adminName, menuDAO, date));
+            // 메뉴 한 개당 하나의 DTO 생성
+            ResponseOrderCookingGetDTO responseOrderCookingGetDTO = createOrderCookingGetDTOBean.exec(adminName, menuDAO, date);
+
+            // DTO가 null이 아니라면 DTO 리스트에 삽입
+            if (responseOrderCookingGetDTO != null) orderCookingGetDTOList.add(responseOrderCookingGetDTO);
 
         }
 


### PR DESCRIPTION
## Docs

- [Issue Link](https://github.com/DEV-TINO/Festino-Admin-BE/issues/115#issue-2499293286)


## Changes

조리중 주문 조회 API : 삭제된 메뉴 중에서 해당하는 Cook이 없는 메뉴는 response에 포함하지 않도록 수정

## Review Points

Order 관련 API가 정상 동작하는가
- order
  - 조리중 주문 조회 : `/admin/booth/{boothId}/order/cooking`

## Test Checklist

- [x] 조리중 주문조회 API