### PR TITLE
Fix : Order

### DIFF
--- a/src/main/java/com/DevTino/festino_admin/order/bean/small/GetOrderBoothNameDAOBean.java
+++ b/src/main/java/com/DevTino/festino_admin/order/bean/small/GetOrderBoothNameDAOBean.java
@@ -12,7 +12,7 @@ public class GetOrderBoothNameDAOBean {
         return switch (boothId.toString()) {
             case "bcb6ddc2-1116-4729-a643-fa8f3bb5408f" -> "computer";
             case "8414328c-f765-4741-bf22-59f5a52e06bf" -> "game";
-            case "3aacd1de-57c1-4685-a94a-63c1664f51bf" -> "new_material";
+            case "3aacd1de-57c1-4685-a94a-63c1664f51bf" -> "newMaterial";
             case "71ced602-eb69-4e0e-96cd-3bcded85fd76" -> "machine";
             case "5167a573-3a5f-4b40-ab9e-22c8fdf16c84" -> "energy";
             case "f0fe6e61-e530-4606-a003-cf224833b11b" -> "electronics";


### PR DESCRIPTION

## Docs

- [Issue Link](https://github.com/DEV-TINO/Festino-Admin-BE/issues/126)


## Changes
부스가 신소재공학과 일때, adminName이 new_material인데 order API 작동시, switch문에서 newMaterial로 표기법이 맞지 않아 API가 정상적으로 작동하지 않는 경우가 발생해 신소재공학과 일때, new_material->newMaterial로 변경

## Review Points
- [x] 수정하고 난 후, API들이 정상 작동하는가
