### PR TITLE
fix: add finishAt

### DIFF
--- a/src/main/java/com/DevTino/festino_admin/order/domain/DTO/OrderDTO.java
+++ b/src/main/java/com/DevTino/festino_admin/order/domain/DTO/OrderDTO.java
@@ -191,6 +191,7 @@ public class OrderDTO {
                 .isCoupon(designOrderDAO.getIsCoupon())
                 .isService(designOrderDAO.getIsService())
                 .createAt(designOrderDAO.getCreateAt())
+                .finishAt(designOrderDAO.getFinishAt())
                 .menuInfo(designOrderDAO.getMenuInfo())
                 .build();
     }


### PR DESCRIPTION
An error occurred in Designs and Completed Orders that prevented them from being sorted by newest first.
The error was caused by not returning finishAt, so I added code to return finishAt.